### PR TITLE
🎨 Palette: Add ARIA labels to icon-only links for accessibility

### DIFF
--- a/TheFourElements.html
+++ b/TheFourElements.html
@@ -445,10 +445,10 @@
     <!-- Footer -->
     <footer>
         <div class="social-icons">
-            <a href="#"><i class="fab fa-facebook-f"></i></a>
-            <a href="#"><i class="fab fa-twitter"></i></a>
-            <a href="#"><i class="fab fa-instagram"></i></a>
-            <a href="#"><i class="fab fa-linkedin-in"></i></a>
+            <a href="#" aria-label="Follow us on Facebook"><i class="fab fa-facebook-f"></i></a>
+            <a href="#" aria-label="Follow us on Twitter"><i class="fab fa-twitter"></i></a>
+            <a href="#" aria-label="Follow us on Instagram"><i class="fab fa-instagram"></i></a>
+            <a href="#" aria-label="Connect with us on LinkedIn"><i class="fab fa-linkedin-in"></i></a>
         </div>
         <p class="copyright">© 2025 Elements of Life. All rights reserved.</p>
     </footer>


### PR DESCRIPTION
💡 **What:** Added descriptive `aria-label` attributes to the icon-only social media links in the footer of `TheFourElements.html`.
🎯 **Why:** Icon-only links without accessible names provide no context to screen reader users, making it unclear what the link does or where it goes.
📸 **Before/After:** Visually identical, but programmatically distinct for assistive technologies.
♿ **Accessibility:** Greatly improves keyboard and screen reader accessibility by ensuring each social media link has a clear, understandable purpose (e.g., "Follow us on Facebook").

Note: Created `.Jules/palette.md` as requested, but added no entries as this is routine accessibility work and not a critical, app-specific learning.

---
*PR created automatically by Jules for task [12330322205365896689](https://jules.google.com/task/12330322205365896689) started by @aldoyh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility of footer social media links by adding descriptive labels for screen readers and assistive technologies, enhancing usability for users with accessibility needs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->