### PR TITLE
🎨 Palette: Add smooth transition to scroll-to-top and keyboard focus indicators

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,6 +142,12 @@
             color: var(--text-color);
             font-size: 1.5rem;
             cursor: pointer;
+            border-radius: 4px;
+        }
+
+        .mobile-menu-btn:focus-visible {
+            outline: 2px solid var(--primary-color);
+            outline-offset: 4px;
         }
 
         /* Main content */
@@ -425,6 +431,12 @@
         .theme-toggle:hover {
             transform: scale(1.1);
             box-shadow: var(--box-shadow);
+        }
+
+        .theme-toggle:focus-visible {
+            outline: 2px solid var(--primary-color);
+            outline-offset: 4px;
+            box-shadow: var(--glow);
         }
 
         /* Responsive design */
@@ -740,14 +752,20 @@
             scrollToTopBtn.id = 'scroll-to-top';
             scrollToTopBtn.setAttribute('aria-label', 'Scroll to top');
             scrollToTopBtn.style.bottom = '8rem';
-            scrollToTopBtn.style.display = 'none';
+            scrollToTopBtn.style.opacity = '0';
+            scrollToTopBtn.style.visibility = 'hidden';
+            scrollToTopBtn.style.pointerEvents = 'none';
             document.body.appendChild(scrollToTopBtn);
 
             window.addEventListener('scroll', function() {
                 if (window.pageYOffset > 300) {
-                    scrollToTopBtn.style.display = 'flex';
+                    scrollToTopBtn.style.opacity = '1';
+                    scrollToTopBtn.style.visibility = 'visible';
+                    scrollToTopBtn.style.pointerEvents = 'auto';
                 } else {
-                    scrollToTopBtn.style.display = 'none';
+                    scrollToTopBtn.style.opacity = '0';
+                    scrollToTopBtn.style.visibility = 'hidden';
+                    scrollToTopBtn.style.pointerEvents = 'none';
                 }
             });
 


### PR DESCRIPTION
### 💡 What
- Replaced abrupt `display: none`/`display: flex` toggling on the scroll-to-top button with a smooth `opacity`, `visibility`, and `pointer-events` transition.
- Added clear `:focus-visible` styles to the mobile menu and theme toggle buttons.

### 🎯 Why
- The scroll-to-top button previously popped in and out of view instantly, which feels jarring. A smooth fade improves visual polish and feels more natural.
- Keyboard users navigating the site had no clear visual indicator of which interactive header button they were focused on.

### 📸 Before/After
- **Before:** Scroll-to-top button abruptly appeared. Focusing on the header icons (menu/theme) with the keyboard showed no outline.
- **After:** Scroll-to-top button fades in smoothly when scrolling down. Tabbing through the header now shows a clear focus ring using existing design system properties (`outline`, `box-shadow`).

### ♿ Accessibility
- Significantly improves keyboard navigation by making it obvious which header button currently has focus, aiding users who cannot or prefer not to use a mouse.

---
*PR created automatically by Jules for task [15954313820464655687](https://jules.google.com/task/15954313820464655687) started by @aldoyh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added visible focus indicators for keyboard navigation on menu and theme toggle buttons
  * Improved scroll-to-top button visibility transitions for a smoother user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->