### PR TITLE
🎨 Palette: Make skip-to-content link visible above sticky header

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-27 - Skip Link Obscured by Sticky Header
+**Learning:** In this application, the sticky header uses a `z-index` of `1000`. Accessibility overlays, specifically the skip-to-content link which drops down from the top of the page on focus, can be obscured by this sticky header if they lack an adequate `z-index`.
+**Action:** When adding or modifying accessibility overlays or new UI elements that need to appear above the sticky header (like skip links or tooltips near the top of the viewport), ensure they are given a `z-index` of `1001` or higher to guarantee visibility.

--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@
             text-decoration: none;
             border-radius: 4px;
             transition: top 0.3s;
+            z-index: 1001; /* Ensure it appears above the sticky header */
         }
 
         .skip-link:focus {


### PR DESCRIPTION
* 💡 What: Added `z-index: 1001` to the `.skip-link` CSS class in `index.html`.
* 🎯 Why: Previously, when keyboard users tabbed onto the "Skip to Content" link, it was hidden beneath the sticky header (which has a `z-index` of 1000). 
* 📸 Before/After: Before, tabbing triggered the link but it was invisible. After, the link appears visually on screen over the header when focused.
* ♿ Accessibility: Ensures that keyboard-only and screen reader users can see the skip link mechanism clearly. Also logged this learning in the Palette journal for future overlay components.

---
*PR created automatically by Jules for task [9710490313603858473](https://jules.google.com/task/9710490313603858473) started by @aldoyh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted z-index layering to ensure skip link renders above sticky header

<!-- end of auto-generated comment: release notes by coderabbit.ai -->