### PR TITLE
🎨 Palette: Fix skip-to-content focus management

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-01-24 - Accessibility Overlays and Sticky Header Constraints
 **Learning:** The application features a fixed sticky header with a `z-index` of 1000. Any accessibility overlays or focusable elements that must appear visually above the content, such as skip-to-content links, must use a `z-index` of 1001 or higher. Otherwise, when focused, they may be hidden behind the sticky header, failing their accessibility purpose.
 **Action:** Always verify the computed `z-index` when adding or modifying skip links, tooltips, or any accessibility elements intended to overlay the main content, ensuring they explicitly declare `z-index: 1001` (or appropriate) to sit above the sticky header context.
+
+## 2025-01-28 - Focus Management with Smooth Scrolling Anchor Links
+**Learning:** When using JavaScript to implement custom smooth scrolling for anchor links (e.g., skip-to-content links or navigation menus), the browser's native focus management is bypassed. If you only use `window.scrollTo()`, the visual viewport changes, but the keyboard focus remains on the clicked link. This breaks keyboard navigation, as the next `Tab` press will jump the user back to the top of the page rather than continuing from the target section.
+**Action:** Always explicitly manage focus when overriding native anchor link behavior. Use `targetElement.setAttribute('tabindex', '-1')` (to make non-interactive elements programmatically focusable) and `targetElement.focus({ preventScroll: true })` to move focus to the destination without disrupting the smooth scroll animation.

--- a/index.html
+++ b/index.html
@@ -688,6 +688,10 @@
                             top: targetElement.offsetTop - 80, // Account for fixed header
                             behavior: 'smooth'
                         });
+
+                        // Set focus to the target element for accessibility
+                        targetElement.setAttribute('tabindex', '-1');
+                        targetElement.focus({ preventScroll: true });
                     }
                 });
             });


### PR DESCRIPTION
### 💡 What
Added explicit focus management when clicking anchor links that use custom JavaScript smooth-scrolling. Specifically, the target element now receives `tabindex="-1"` and `.focus({ preventScroll: true })`.

### 🎯 Why
When overriding native anchor links (`href="#id"`) with `window.scrollTo`, the browser's native focus management is bypassed. This meant that keyboard users clicking the "Skip to content" link would scroll down, but their focus would remain at the top of the page. This fix ensures keyboard users can seamlessly continue tabbing from the main content.

### 📸 Before/After
*   **Before:** Clicking "Skip to content" scrolls to the main content, but the next `Tab` press focuses the first link in the header.
*   **After:** Clicking "Skip to content" scrolls to the main content, and the next `Tab` press focuses the first interactive element inside the main content.

### ♿ Accessibility
*   **Keyboard Navigation:** Directly fixes a critical focus order bug for keyboard and screen reader navigation.
*   **Prevent Scroll:** Uses `preventScroll: true` when focusing to prevent jarring double-scroll jumps when combining smooth scrolling with manual focus.

---
*PR created automatically by Jules for task [8398308701643878470](https://jules.google.com/task/8398308701643878470) started by @aldoyh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Added detailed guidance on managing keyboard focus when implementing custom smooth scrolling functionality that overrides default anchor link behavior. Includes documented focus-shifting techniques and recommended patterns.

## New Features
- Implemented keyboard focus management for anchor link navigation. Anchor links now programmatically control focus state and tabindex settings to ensure proper keyboard navigation behavior throughout smooth scrolling operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->