### PR TITLE
🎨 Palette: Fix smooth scrolling keyboard focus management

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,8 @@
             outline-offset: 4px;
         }
 
-        #main-content:focus {
+        #main-content:focus,
+        section:focus {
             outline: none;
         }
 
@@ -556,7 +557,7 @@
         }
     </style>
 </head>
-<body>
+<body id="home">
     <a href="#main-content" class="skip-link">Skip to content</a>
 
     <header id="main-header">
@@ -760,6 +761,7 @@
                         });
 
                         // Set focus to the target element for accessibility
+                        targetElement.setAttribute('tabindex', '-1');
                         targetElement.focus({ preventScroll: true });
 
                         // Update URL hash without jumping


### PR DESCRIPTION
💡 What:
Updated the smooth scrolling JavaScript logic to properly manage keyboard focus for screen readers and keyboard users. Added `id="home"` to the `<body>` element so the navigation logo link functions properly. Added `section:focus { outline: none; }` to prevent focus rings from appearing around large layout sections when navigating.

🎯 Why:
Smooth scrolling navigation breaks keyboard navigation if focus isn't programmatically moved to the destination element. Adding `tabindex="-1"` allows the `focus()` function to work correctly without inserting structural elements into the natural tab flow.

📸 Before/After:
Before: Clicking "Water" visually scrolled to the water section, but the user's keyboard tab focus remained on the navigation bar.
After: Clicking "Water" visually scrolls to the water section, and the user's next `Tab` keystroke continues from within that new section.

♿ Accessibility:
Properly manages focus flow during SPA-like hash navigation, fixing a widespread WCAG failure where keyboard users get trapped or lost after clicking a navigation link.

---
*PR created automatically by Jules for task [14798401821964023341](https://jules.google.com/task/14798401821964023341) started by @aldoyh*